### PR TITLE
fix: meta href APP_URL

### DIFF
--- a/apps/web/src/pages/[locale]/index.astro
+++ b/apps/web/src/pages/[locale]/index.astro
@@ -34,11 +34,14 @@ export const getStaticPaths = async () => {
   return paths;
 };
 
-const { meta, sections } = Astro.props;
+const { meta: metaRaw, sections: sectionsRaw } = Astro.props;
 
 const appUrl = urlWithPR(import.meta.env.PUBLIC_APP_URL) as string;
-const parsed = JSON.parse(
-  JSON.stringify(sections).replaceAll("{{APP_URL}}", appUrl)
+const sections = JSON.parse(
+  JSON.stringify(sectionsRaw).replaceAll("{{APP_URL}}", appUrl)
+);
+const meta = JSON.parse(
+  JSON.stringify(metaRaw).replaceAll("{{APP_URL}}", appUrl)
 );
 ---
 
@@ -51,7 +54,7 @@ const parsed = JSON.parse(
   structuredData={meta.structuredData}
 >
   {
-    parsed.map((section: any, idx: number) => {
+    sections.map((section: any, idx: number) => {
       switch (section.type) {
         case "Hero":
           return <Hero {...section.props} />;

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -17,23 +17,24 @@ import { defaultLang } from "@/i18n/ui";
 const landing = await getEntry("landings", `${defaultLang}/quizbee-base`);
 
 const appUrl = urlWithPR(import.meta.env.PUBLIC_APP_URL) as string;
-const parsed = JSON.parse(
+const sections = JSON.parse(
   JSON.stringify(landing?.data.sections).replaceAll("{{APP_URL}}", appUrl)
 );
-
-const { meta } = landing?.data ?? {};
+const meta = JSON.parse(
+  JSON.stringify(landing?.data.meta).replaceAll("{{APP_URL}}", appUrl)
+);
 ---
 
 <Root
-  title={meta.title}
-  description={meta.description}
-  image={meta.image}
-  active={meta.active || "home"}
-  headerCtaHref={meta.headerCtaHref}
-  structuredData={meta.structuredData}
+  title={meta?.title || "QuizBee"}
+  description={meta?.description}
+  image={meta?.image}
+  active={meta?.active || "home"}
+  headerCtaHref={meta?.headerCtaHref}
+  structuredData={meta?.structuredData}
 >
   {
-    parsed.map((section: any, idx: number) => {
+    sections.map((section: any, idx: number) => {
       switch (section.type) {
         case "Hero":
           return <Hero {...section.props} />;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces APP_URL placeholders in both meta and sections for landing pages and makes meta access null-safe with a default title.
> 
> - **Web landing pages**:
>   - Apply `{{APP_URL}}` replacement to both `meta` and `sections` in `apps/web/src/pages/[locale]/index.astro` and `apps/web/src/pages/index.astro`.
>   - Rename `parsed` to `sections` and update mappings accordingly.
>   - Make `meta` usage null-safe with defaults (e.g., `title` fallback) in `apps/web/src/pages/index.astro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c884119cf77654759627f0726267352611072cef. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->